### PR TITLE
Fix black line length

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -53,8 +53,7 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
     # quoting rules for Python and bash, but strip the outermost quotes so we
     # can detect paths within the bindir, like <bindir>/python.
     bindirs = [
-        bindir[1:-1] if bindir[0] in "'\"" else bindir
-        for bindir in (repr(session.bin), shlex.quote(session.bin))
+        bindir[1:-1] if bindir[0] in "'\"" else bindir for bindir in (repr(session.bin), shlex.quote(session.bin))
     ]
 
     virtualenv = session.env.get("VIRTUAL_ENV")
@@ -96,10 +95,7 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
 
         text = hook.read_text()
 
-        if not any(
-            Path("A") == Path("a") and bindir.lower() in text.lower() or bindir in text
-            for bindir in bindirs
-        ):
+        if not any(Path("A") == Path("a") and bindir.lower() in text.lower() or bindir in text for bindir in bindirs):
             continue
 
         lines = text.splitlines()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1949,13 +1949,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.2.1"
+version = "2.2.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "urllib3-2.2.1-py3-none-any.whl", hash = "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"},
-    {file = "urllib3-2.2.1.tar.gz", hash = "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"},
+    {file = "urllib3-2.2.2-py3-none-any.whl", hash = "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472"},
+    {file = "urllib3-2.2.2.tar.gz", hash = "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ pytest-static = "pytest_static.__main__:main"
 [tool.poetry.plugins."pytest"]
 pytest-static= "pytest_static.plugin"
 
+[tool.black]
+line-length = 120
+
 [tool.coverage.paths]
 source = ["src", "*/site-packages"]
 tests = ["tests", "*/tests"]

--- a/src/pytest_static/exceptions.py
+++ b/src/pytest_static/exceptions.py
@@ -7,8 +7,5 @@ class ExpandedTypeNotCallableError(TypeError):
     """Exception raised if a non-Callable base_type is being cast as Callable."""
 
     def __init__(self, base_type: Any, *args: Any):
-        msg: str = (
-            f"Attempted to cast a non callable type of {type(base_type)} "
-            f"as callable."
-        )
+        msg: str = f"Attempted to cast a non callable type of {type(base_type)} " f"as callable."
         super().__init__(msg, *args)

--- a/src/pytest_static/parametric.py
+++ b/src/pytest_static/parametric.py
@@ -82,12 +82,8 @@ def parametrize_types(
     if len(argnames) != len(argtypes):
         raise ValueError("Parameter names and types count must match.")
 
-    parameter_sets: list[list[T]] = [
-        list(get_all_possible_type_instances(t)) for t in argtypes
-    ]
-    parameter_combinations: list[tuple[T, ...]] = list(
-        itertools.product(*parameter_sets)
-    )
+    parameter_sets: list[list[T]] = [list(get_all_possible_type_instances(t)) for t in argtypes]
+    parameter_combinations: list[tuple[T, ...]] = list(itertools.product(*parameter_sets))
 
     if ids is None:
         ids = [", ".join(map(repr, pairs)) for pairs in parameter_combinations]
@@ -120,9 +116,7 @@ def iter_instances(typ: Any) -> Generator[Any, None, None]:
     base_type: Any = origin if origin is not None else typ
 
     handler: (
-        Callable[[Any, tuple[Any, ...]], Generator[Any, None, None]]
-        | partial[Generator[Any, None, None]]
-        | None
+        Callable[[Any, tuple[Any, ...]], Generator[Any, None, None]] | partial[Generator[Any, None, None]] | None
     ) = TYPE_HANDLERS.get(base_type, None)
 
     if handler is None:
@@ -131,28 +125,20 @@ def iter_instances(typ: Any) -> Generator[Any, None, None]:
         yield from handler(base_type, type_args)
 
 
-def _iter_literal_instances(
-    base_type: Any, type_args: tuple[Any, ...]
-) -> Generator[Any, None, None]:
+def _iter_literal_instances(base_type: Any, type_args: tuple[Any, ...]) -> Generator[Any, None, None]:
     yield from type_args
 
 
-def _iter_any_instances(
-    base_type: Any, type_args: tuple[Any, ...]
-) -> Generator[Any, None, None]:
+def _iter_any_instances(base_type: Any, type_args: tuple[Any, ...]) -> Generator[Any, None, None]:
     for typ in PREDEFINED_INSTANCE_SETS.keys():
         yield from iter_instances(typ)
 
 
-def _iter_predefined_instances(
-    base_type: Any, type_args: tuple[Any, ...]
-) -> Generator[Any, None, None]:
+def _iter_predefined_instances(base_type: Any, type_args: tuple[Any, ...]) -> Generator[Any, None, None]:
     yield from PREDEFINED_INSTANCE_SETS[base_type]
 
 
-def _iter_sum_instances(
-    _: Any, type_args: tuple[Any, ...]
-) -> Generator[Any, None, None]:
+def _iter_sum_instances(_: Any, type_args: tuple[Any, ...]) -> Generator[Any, None, None]:
     for arg in type_args:
         yield from get_all_possible_type_instances(arg)
 
@@ -166,25 +152,16 @@ def _iter_product_instances_with_constructor(
     if Ellipsis in type_args:
         type_args = type_args[:-1]
 
-    combinations: Iterable[Iterable[Any]] = itertools.product(
-        *(iter_instances(arg) for arg in type_args)
-    )
+    combinations: Iterable[Iterable[Any]] = itertools.product(*(iter_instances(arg) for arg in type_args))
     yield from map(type_constructor, map(tuple, combinations))
 
 
-def _validate_combination_length(
-    combination: tuple[Any, ...], expected_length: int, typ: type[Any]
-) -> None:
+def _validate_combination_length(combination: tuple[Any, ...], expected_length: int, typ: type[Any]) -> None:
     if len(combination) != expected_length:
-        raise TypeError(
-            f"Expected combination of length {expected_length} for "
-            f"type {typ}. Got {len(combination)}"
-        )
+        raise TypeError(f"Expected combination of length {expected_length} for " f"type {typ}. Got {len(combination)}")
 
 
-def _iter_custom_instances(
-    base_type: Any, type_args: tuple[Any, ...]
-) -> Generator[Any, None, None]:
+def _iter_custom_instances(base_type: Any, type_args: tuple[Any, ...]) -> Generator[Any, None, None]:
     """Planned for future, but not yet implemented."""
     raise NotImplementedError
 
@@ -205,9 +182,7 @@ def _set_constructor(combination: tuple[T]) -> set[T]:
 
 
 def _frozenset_constructor(combination: tuple[T]) -> frozenset[T]:
-    _validate_combination_length(
-        combination=combination, expected_length=1, typ=frozenset
-    )
+    _validate_combination_length(combination=combination, expected_length=1, typ=frozenset)
     return frozenset(combination)
 
 
@@ -240,15 +215,14 @@ _iter_tuple_instances: partial[Generator[Any, None, None]] = partial(
 )
 
 
-PREDEFINED_TYPE_SET_HANDLERS: dict[
-    type[Any], Callable[[Any, tuple[Any, ...]], Generator[Any, None, None]]
-] = {typ: _iter_predefined_instances for typ in PREDEFINED_INSTANCE_SETS.keys()}
+PREDEFINED_TYPE_SET_HANDLERS: dict[type[Any], Callable[[Any, tuple[Any, ...]], Generator[Any, None, None]]] = {
+    typ: _iter_predefined_instances for typ in PREDEFINED_INSTANCE_SETS.keys()
+}
 
 
 TYPE_HANDLERS: dict[
     Any,
-    Callable[[Any, tuple[Any, ...]], Generator[Any, None, None]]
-    | partial[Generator[Any, None, None]],
+    Callable[[Any, tuple[Any, ...]], Generator[Any, None, None]] | partial[Generator[Any, None, None]],
 ] = {
     **PREDEFINED_TYPE_SET_HANDLERS,
     Literal: _iter_literal_instances,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -21,7 +21,5 @@ from tests.util import _get_origin_string
         (Dict[int, int], "Dict"),
     ],
 )
-def test__get_origin_string_with_special_generic_alias(
-    annotation: Any, expected: str
-) -> None:
+def test__get_origin_string_with_special_generic_alias(annotation: Any, expected: str) -> None:
     assert _get_origin_string(annotation) == expected

--- a/tests/unit_tests/test_parametric.py
+++ b/tests/unit_tests/test_parametric.py
@@ -40,9 +40,7 @@ def assert_len(iterable: Iterable[Any], expected: int) -> None:
 
 
 def test_get_all_possible_type_instances(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        pytest_static.parametric, "iter_instances", dummy_iter_instances
-    )
+    monkeypatch.setattr(pytest_static.parametric, "iter_instances", dummy_iter_instances)
     assert get_all_possible_type_instances(int) == (1, 2, 3)
 
 

--- a/tests/unit_tests/test_plugin.py
+++ b/tests/unit_tests/test_plugin.py
@@ -38,14 +38,10 @@ def argtypes(request: FixtureRequest) -> Sequence[str]:
 
 
 @pytest.fixture
-def parametrize_types_test(
-    pytester: Pytester, conftest: Path, argtypes: Sequence[str]
-) -> Path:
+def parametrize_types_test(pytester: Pytester, conftest: Path, argtypes: Sequence[str]) -> Path:
     argnames: list[str] = [f"arg{i}" for i in range(len(argtypes))]
     argtypes_formatted: str = ", ".join([f"{argtype}" for argtype in argtypes])
-    signature: str = ", ".join(
-        [f"{argname}" for argname, argtype in zip(argnames, argtypes)]
-    )
+    signature: str = ", ".join([f"{argname}" for argname, argtype in zip(argnames, argtypes)])
 
     return pytester.makepyfile(
         f"""
@@ -66,9 +62,7 @@ def parametrize_types_test(
     )
 
 
-def test_parametrize_types_with_unequal_names_and_types(
-    pytester: Pytester, conftest: Path
-) -> None:
+def test_parametrize_types_with_unequal_names_and_types(pytester: Pytester, conftest: Path) -> None:
     test_path: Path = pytester.makepyfile(
         """
         import pytest
@@ -88,9 +82,7 @@ def test_parametrize_types_with_unequal_names_and_types(
     result.assert_outcomes(errors=1)
 
 
-def test_parametrize_types_with_no_ids_provided(
-    pytester: Pytester, conftest: Path
-) -> None:
+def test_parametrize_types_with_no_ids_provided(pytester: Pytester, conftest: Path) -> None:
     test_path: Path = pytester.makepyfile(
         """
         import pytest
@@ -110,9 +102,7 @@ def test_parametrize_types_with_no_ids_provided(
     result.assert_outcomes(passed=4)
 
 
-def test_parametrize_types_with_argnames_as_string(
-    pytester: Pytester, conftest: Path
-) -> None:
+def test_parametrize_types_with_argnames_as_string(pytester: Pytester, conftest: Path) -> None:
     test_path: Path = pytester.makepyfile(
         """
         import pytest
@@ -145,9 +135,7 @@ def test_parametrize_types_with_argnames_as_string(
     ids=lambda x: str(x) if isinstance(x, Iterable) else x,
     indirect=["argtypes"],
 )
-def test_parametrize_types_with_single_basic(
-    pytester: Pytester, parametrize_types_test: Path, expected: int
-) -> None:
+def test_parametrize_types_with_single_basic(pytester: Pytester, parametrize_types_test: Path, expected: int) -> None:
     result: pytest.RunResult = pytester.runpytest(parametrize_types_test)
     result.assert_outcomes(passed=expected)
 
@@ -160,9 +148,7 @@ def test_parametrize_types_with_single_basic(
     ids=lambda x: str(x) if isinstance(x, Iterable) else x,
     indirect=["argtypes"],
 )
-def test_parametrize_types_with_multiple_basic(
-    pytester: Pytester, parametrize_types_test: Path, expected: int
-) -> None:
+def test_parametrize_types_with_multiple_basic(pytester: Pytester, parametrize_types_test: Path, expected: int) -> None:
     result: pytest.RunResult = pytester.runpytest(parametrize_types_test)
     result.assert_outcomes(passed=expected)
 
@@ -211,10 +197,7 @@ def test_parametrize_types_with_multiple_expanded(
 
 @pytest.mark.parametrize(
     argnames=["argtypes", "expected"],
-    argvalues=[
-        ((type_annotation_to_string(typ),), expected)
-        for typ, expected in SPECIAL_TYPE_EXPECTED_EXAMPLES
-    ],
+    argvalues=[((type_annotation_to_string(typ),), expected) for typ, expected in SPECIAL_TYPE_EXPECTED_EXAMPLES],
     ids=lambda x: str(x) if isinstance(x, Iterable) else x,
     indirect=["argtypes"],
 )
@@ -227,10 +210,7 @@ def test_parametrize_types_with_special_type_expected_examples(
 
 @pytest.mark.parametrize(
     argnames=["argtypes", "expected"],
-    argvalues=[
-        ((type_annotation_to_string(typ),), expected)
-        for typ, expected in BASIC_TYPE_EXPECTED_EXAMPLES
-    ],
+    argvalues=[((type_annotation_to_string(typ),), expected) for typ, expected in BASIC_TYPE_EXPECTED_EXAMPLES],
     ids=lambda x: str(x) if isinstance(x, Iterable) else x,
     indirect=["argtypes"],
 )
@@ -243,10 +223,7 @@ def test_parametrize_types_with_basic_type_expected_examples(
 
 @pytest.mark.parametrize(
     argnames=["argtypes", "expected"],
-    argvalues=[
-        ((type_annotation_to_string(typ),), expected)
-        for typ, expected in SUM_TYPE_EXPECTED_EXAMPLES
-    ],
+    argvalues=[((type_annotation_to_string(typ),), expected) for typ, expected in SUM_TYPE_EXPECTED_EXAMPLES],
     ids=lambda x: str(x) if isinstance(x, Iterable) else x,
     indirect=["argtypes"],
 )
@@ -259,10 +236,7 @@ def test_parametrize_types_with_sum_type_expected_examples(
 
 @pytest.mark.parametrize(
     argnames=["argtypes", "expected"],
-    argvalues=[
-        ((type_annotation_to_string(typ),), expected)
-        for typ, expected in PRODUCT_TYPE_EXPECTED_EXAMPLES
-    ],
+    argvalues=[((type_annotation_to_string(typ),), expected) for typ, expected in PRODUCT_TYPE_EXPECTED_EXAMPLES],
     ids=lambda x: str(x) if isinstance(x, Iterable) else x,
     indirect=["argtypes"],
 )

--- a/tests/util.py
+++ b/tests/util.py
@@ -28,16 +28,7 @@ STR_LEN: int = len(PREDEFINED_INSTANCE_SETS[str])
 BYTES_LEN: int = len(PREDEFINED_INSTANCE_SETS[bytes])
 NONE_LEN: int = 1
 ELLIPSIS_LEN: int = 0
-ANY_LEN: int = (
-    BOOL_LEN
-    + INT_LEN
-    + FLOAT_LEN
-    + COMPLEX_LEN
-    + STR_LEN
-    + BYTES_LEN
-    + NONE_LEN
-    + ELLIPSIS_LEN
-)
+ANY_LEN: int = BOOL_LEN + INT_LEN + FLOAT_LEN + COMPLEX_LEN + STR_LEN + BYTES_LEN + NONE_LEN + ELLIPSIS_LEN
 
 
 SPECIAL_TYPE_EXPECTED_EXAMPLES: list[tuple[Any, int]] = [
@@ -151,15 +142,11 @@ def _get_origin_string(annotation: Any) -> str:
         annotation_name = annotation.__name__
     elif origin is not None:
         annotation_name_with_generics: str = str(annotation)
-        annotation_name = annotation_name_with_generics.split("[")[
-            0
-        ]  # Should never not be a generic here
+        annotation_name = annotation_name_with_generics.split("[")[0]  # Should never not be a generic here
     else:
         annotation_name = str(annotation)
 
-    annotation_name_without_module: str = _remove_typing_module_from_str(
-        annotation_name
-    )
+    annotation_name_without_module: str = _remove_typing_module_from_str(annotation_name)
     if annotation_name_without_module == "Optional":
         return "Union"
     return annotation_name_without_module


### PR DESCRIPTION
Adds a setting to pyproject.toml to ensure black doesn't format lines to 88 characters despite flake8 doing 120.