### PR TITLE
Update certifi for CVE-2024-39689

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2230,4 +2230,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,<4.0"
-content-hash = "311d2ab63321549e5c55bd7fd58bb558f0f85c5c9f68d7f73f1c44d74cfa912f"
+content-hash = "43e8fd5a78866f0f76e82469748d80f53f3c37e89c7295405e735c0a2de47eb5"

--- a/poetry.lock
+++ b/poetry.lock
@@ -184,13 +184,13 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "certifi"
-version = "2024.7.4"
+version = "2024.6.2"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2024.7.4-py3-none-any.whl", hash = "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"},
-    {file = "certifi-2024.7.4.tar.gz", hash = "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b"},
+    {file = "certifi-2024.6.2-py3-none-any.whl", hash = "sha256:ddc6c8ce995e6987e7faf5e3f1b02b302836a0e5d98ece18392cb1a36c72ad56"},
+    {file = "certifi-2024.6.2.tar.gz", hash = "sha256:3cd43f1c6fa7dedc5899d69d3ad0398fd018ad1a17fba83ddaf78aa46c747516"},
 ]
 
 [[package]]
@@ -2230,4 +2230,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,<4.0"
-content-hash = "311d2ab63321549e5c55bd7fd58bb558f0f85c5c9f68d7f73f1c44d74cfa912f"
+content-hash = "d731a2f4cc2ff1c25a08aad7f8f6e0c8f81ceae87c6f5179286c80f597a1b7b2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -184,13 +184,13 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "certifi"
-version = "2024.6.2"
+version = "2024.7.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2024.6.2-py3-none-any.whl", hash = "sha256:ddc6c8ce995e6987e7faf5e3f1b02b302836a0e5d98ece18392cb1a36c72ad56"},
-    {file = "certifi-2024.6.2.tar.gz", hash = "sha256:3cd43f1c6fa7dedc5899d69d3ad0398fd018ad1a17fba83ddaf78aa46c747516"},
+    {file = "certifi-2024.7.4-py3-none-any.whl", hash = "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"},
+    {file = "certifi-2024.7.4.tar.gz", hash = "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b"},
 ]
 
 [[package]]
@@ -2230,4 +2230,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,<4.0"
-content-hash = "d731a2f4cc2ff1c25a08aad7f8f6e0c8f81ceae87c6f5179286c80f597a1b7b2"
+content-hash = "311d2ab63321549e5c55bd7fd58bb558f0f85c5c9f68d7f73f1c44d74cfa912f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,10 +64,6 @@ pytest-static = "pytest_static.__main__:main"
 [tool.poetry.plugins."pytest"]
 pytest-static= "pytest_static.plugin"
 
-
-[tool.poetry.group.dev.dependencies]
-certifi = ">=2024.7.4"
-
 [tool.black]
 line-length = 120
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ typing-extensions = "^4.9.0"
 Pygments = ">=2.10.0"
 bandit = ">=1.7.4"
 black = ">=21.10b0"
+certifi = ">=2024.7.4"
 coverage = {extras = ["toml"], version = ">=6.2"}
 darglint = ">=1.8.1"
 flake8 = ">=4.0.1"
@@ -63,10 +64,6 @@ pytest-static = "pytest_static.__main__:main"
 
 [tool.poetry.plugins."pytest"]
 pytest-static= "pytest_static.plugin"
-
-
-[tool.poetry.group.dev.dependencies]
-certifi = ">=2024.7.4"
 
 [tool.black]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,10 @@ pytest-static = "pytest_static.__main__:main"
 [tool.poetry.plugins."pytest"]
 pytest-static= "pytest_static.plugin"
 
+
+[tool.poetry.group.dev.dependencies]
+certifi = ">=2024.7.4"
+
 [tool.black]
 line-length = 120
 


### PR DESCRIPTION
Adds a dev dependency of "certifi>=2024.7.4" in order to fix [CVE-2024-39689](https://data.safetycli.com/v/72083/97c/).