### PR TITLE
Set Dependabot's target branch to develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,18 +2,22 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: weekly
   - package-ecosystem: pip
     directory: "/.github/workflows"
+    target-branch: "develop"
     schedule:
       interval: weekly
   - package-ecosystem: pip
     directory: "/docs"
+    target-branch: "develop"
     schedule:
       interval: weekly
   - package-ecosystem: pip
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: weekly
     versioning-strategy: lockfile-only


### PR DESCRIPTION
This PR just changes the dependabot.yml file so that Dependabot will target develop instead of master when making pull requests.